### PR TITLE
Implement App Role 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   terraform:
+    name: Terraform Quality Check
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +31,7 @@ jobs:
         run: terraform validate
 
   ansible:
+    name: Ansible Quality Check
     runs-on: ubuntu-latest
 
     steps:
@@ -46,8 +48,12 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run Ansible Lint
-        run: ansible-lint ansible/
+        run: ansible-lint ansible/playbooks/site.yml
+        env:
+          ANSIBLE_ROLES_PATH: ${{ github.workspace }}/ansible/roles
 
       - name: Ansible Syntax Check
         run: |
           ansible-playbook --syntax-check -i ansible/inventory/hosts.ini ansible/playbooks/site.yml
+        env:
+          ANSIBLE_ROLES_PATH: ${{ github.workspace }}/ansible/roles

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ docker-compose.override.yml
 # ----------------------
 .DS_Store
 Thumbs.db
+ansible/roles/app/vars/main.yml

--- a/README.md
+++ b/README.md
@@ -139,10 +139,11 @@ python -m pip install --upgrade pip
 pip install -r requirements.txt`
 ```
 
-Configuration (Ansible)
+To run the Ansible playbooks
 ```
-# From project root with ansible-env activated
-ansible-playbook -i ansible/inventory/hosts.ini ansible/playbooks/site.yml
+source ansible-env/bin/activate
+cd ansible
+ansible-playbook playbooks/site.yml
 
 # Test connectivity
 ansible all -m ping

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,8 +1,0 @@
-[defaults]
-inventory = ./ansible/inventory/hosts.ini
-remote_tmp = /tmp
-remote_user = root
-roles_path = ./ansible/roles
-
-[connection]
-pipelining = True

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,4 +1,8 @@
 [defaults]
-inventory = inventory/hosts.ini
-roles_path = roles
+inventory = ./inventory/hosts.ini
+roles_path = ./roles
+remote_tmp = /tmp
 host_key_checking = False
+
+[ssh_connection]
+pipelining = True

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -1,11 +1,11 @@
-[webservers]
-web ansible_connection=docker
+[web]
+web_node ansible_connection=docker
 
-[appservers]
-app ansible_connection=docker
+[app]
+app_node ansible_connection=docker
 
-[dbservers]
-db ansible_connection=docker
+[db]
+db_node ansible_connection=docker
 
 [all:vars]
 ansible_user=root

--- a/ansible/inventory/hosts.ini
+++ b/ansible/inventory/hosts.ini
@@ -9,5 +9,4 @@ db_node ansible_connection=docker
 
 [all:vars]
 ansible_user=root
-ansible_shell_type=sh
 ansible_python_interpreter=/usr/bin/python3

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -6,14 +6,10 @@
   roles:
     - common
 
-- name: Post-bootstrap validation
+- name: Gather facts after Python install
   hosts: all
   become: true
   gather_facts: true
-  tasks:
-    - name: Confirm Python is ready
-      ansible.builtin.debug:
-        msg: "Python installed, continuing configuration"
 
 - name: Configure app node
   hosts: app

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -13,3 +13,10 @@
     - name: Confirm Python is ready
       ansible.builtin.debug:
         msg: "Python installed, continuing configuration"
+
+- name: Configure app node
+  hosts: appservers
+  become: true
+  gather_facts: true
+  roles:
+    - app

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -15,7 +15,7 @@
         msg: "Python installed, continuing configuration"
 
 - name: Configure app node
-  hosts: appservers
+  hosts: app_node
   become: true
   gather_facts: true
   roles:

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -16,7 +16,7 @@
         msg: "Python installed, continuing configuration"
 
 - name: Configure app node
-  hosts: appservers
+  hosts: app
   become: true
   gather_facts: true
   roles:

--- a/ansible/playbooks/site.yml
+++ b/ansible/playbooks/site.yml
@@ -1,3 +1,4 @@
+---
 - name: Base infrastructure setup
   hosts: all
   become: true
@@ -14,18 +15,9 @@
       ansible.builtin.debug:
         msg: "Python installed, continuing configuration"
 
-<<<<<<< HEAD
 - name: Configure app node
-  hosts: app_node
+  hosts: appservers
   become: true
   gather_facts: true
   roles:
     - app
-=======
-- name: Configure web server (nginx)
-  hosts: web
-  become: true
-  gather_facts: true
-  roles:
-    - web
->>>>>>> c4027318d464ce9bcab040f44540aa536e76f956

--- a/ansible/roles/app/files/app.py
+++ b/ansible/roles/app/files/app.py
@@ -1,6 +1,14 @@
+import os
 from flask import Flask
 
 app = Flask(__name__)
+
+# Credentials come from environment only
+DB_HOST = os.getenv('DB_HOST')
+DB_PORT = os.getenv('DB_PORT')
+DB_NAME = os.getenv('DB_NAME')
+DB_USER = os.getenv('DB_USER')
+DB_PASS = os.getenv('DB_PASS')
 
 @app.route('/')
 def home():
@@ -9,6 +17,22 @@ def home():
 @app.route('/health')
 def health():
     return "Healthy", 200
+
+@app.route('/db-check')
+def db_check():
+    try:
+        import psycopg2
+        conn = psycopg2.connect(
+            host=DB_HOST,
+            port=DB_PORT,
+            dbname=DB_NAME,
+            user=DB_USER,
+            password=DB_PASS
+        )
+        conn.close()
+        return "DB Connection Successful!", 200
+    except Exception as e:
+        return f"DB Connection Failed: {str(e)}", 500
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000)

--- a/ansible/roles/app/files/app.py
+++ b/ansible/roles/app/files/app.py
@@ -1,0 +1,14 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def home():
+    return "App Node is Running!", 200
+
+@app.route('/health')
+def health():
+    return "Healthy", 200
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/ansible/roles/app/handlers/main.yml
+++ b/ansible/roles/app/handlers/main.yml
@@ -6,4 +6,3 @@
       nohup python3 /var/www/app/app.py &
     executable: /bin/bash
   changed_when: false
-

--- a/ansible/roles/app/handlers/main.yml
+++ b/ansible/roles/app/handlers/main.yml
@@ -6,4 +6,4 @@
       nohup python3 /var/www/app/app.py &
     executable: /bin/bash
   changed_when: false
-  
+

--- a/ansible/roles/app/handlers/main.yml
+++ b/ansible/roles/app/handlers/main.yml
@@ -6,3 +6,4 @@
       nohup python3 /var/www/app/app.py &
     executable: /bin/bash
   changed_when: false
+  

--- a/ansible/roles/app/handlers/main.yml
+++ b/ansible/roles/app/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart app
+  shell: |
+    pkill -f app.py || true
+    nohup python3 /var/www/app/app.py &

--- a/ansible/roles/app/handlers/main.yml
+++ b/ansible/roles/app/handlers/main.yml
@@ -1,5 +1,8 @@
 ---
-- name: restart app
-  shell: |
-    pkill -f app.py || true
-    nohup python3 /var/www/app/app.py &
+- name: Restart app
+  ansible.builtin.shell:
+    cmd: |
+      pkill -f app.py || true
+      nohup python3 /var/www/app/app.py &
+    executable: /bin/bash
+  changed_when: false

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -6,7 +6,7 @@
       - python3-venv
       - curl
     state: present
-    update_cache: yes
+    update_cache: true
 
 - name: Create virtual environment
   ansible.builtin.command:

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -1,12 +1,22 @@
 ---
-- name: Install pip
+- name: Install pip and dependencies
   ansible.builtin.apt:
-    name: python3-pip
+    name:
+      - python3-pip
+      - python3-venv
+      - curl
     state: present
+    update_cache: yes
 
-- name: Install Flask
+- name: Create virtual environment
+  ansible.builtin.command:
+    cmd: python3 -m venv /var/www/app/venv
+    creates: /var/www/app/venv
+
+- name: Install Flask in virtualenv
   ansible.builtin.pip:
-    name: flask
+    name: flask==3.0.0
+    virtualenv: /var/www/app/venv
     state: present
 
 - name: Deploy application file
@@ -17,7 +27,7 @@
 
 - name: Start Flask app in background
   ansible.builtin.shell:
-    cmd: nohup python3 /var/www/app/app.py &
+    cmd: nohup /var/www/app/venv/bin/python3 /var/www/app/app.py &
     executable: /bin/bash
   changed_when: false
 

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -25,5 +25,3 @@
   ansible.builtin.wait_for:
     port: 5000
     timeout: 10
-
-

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -13,9 +13,11 @@
     cmd: python3 -m venv /var/www/app/venv
     creates: /var/www/app/venv
 
-- name: Install Flask in virtualenv
+- name: Install Flask and psycopg2 in virtualenv
   ansible.builtin.pip:
-    name: flask==3.0.0
+    name:
+      - flask==3.0.0
+      - psycopg2-binary
     virtualenv: /var/www/app/venv
     state: present
 
@@ -24,8 +26,23 @@
     src: app.py
     dest: /var/www/app/app.py
     mode: '0755'
+    owner: appuser
+    group: appuser
 
-- name: Start Flask app in background
+- name: Create app environment file
+  ansible.builtin.copy:
+    content: |
+      DB_HOST={{ db_host }}
+      DB_PORT={{ db_port }}
+      DB_NAME={{ db_name }}
+      DB_USER={{ db_user }}
+      DB_PASS={{ db_pass }}
+    dest: /var/www/app/.env
+    mode: '0600'
+    owner: appuser
+    group: appuser
+
+- name: Start Flask app
   ansible.builtin.shell:
     cmd: nohup /var/www/app/venv/bin/python3 /var/www/app/app.py &
     executable: /bin/bash

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -25,4 +25,5 @@
   ansible.builtin.wait_for:
     port: 5000
     timeout: 10
-    
+
+

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -25,3 +25,4 @@
   ansible.builtin.wait_for:
     port: 5000
     timeout: 10
+    

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -1,26 +1,27 @@
 ---
 - name: Install pip
-  apt:
+  ansible.builtin.apt:
     name: python3-pip
     state: present
 
-- name: Install Flask 
-  pip:
+- name: Install Flask
+  ansible.builtin.pip:
     name: flask
     state: present
 
 - name: Deploy application file
-  copy:
+  ansible.builtin.copy:
     src: app.py
     dest: /var/www/app/app.py
     mode: '0755'
 
 - name: Start Flask app in background
-  shell: nohup python3 /var/www/app/app.py &
-  args:
+  ansible.builtin.shell:
+    cmd: nohup python3 /var/www/app/app.py &
     executable: /bin/bash
+  changed_when: false
 
 - name: Verify app is running on port 5000
-  wait_for:
+  ansible.builtin.wait_for:
     port: 5000
     timeout: 10

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Install pip
+  apt:
+    name: python3-pip
+    state: present
+
+- name: Install Flask 
+  pip:
+    name: flask
+    state: present
+
+- name: Deploy application file
+  copy:
+    src: app.py
+    dest: /var/www/app/app.py
+    mode: '0755'
+
+- name: Start Flask app in background
+  shell: nohup python3 /var/www/app/app.py &
+  args:
+    executable: /bin/bash
+
+- name: Verify app is running on port 5000
+  wait_for:
+    port: 5000
+    timeout: 10

--- a/ansible/roles/app/vars/main.yml.example
+++ b/ansible/roles/app/vars/main.yml.example
@@ -1,0 +1,7 @@
+---
+db_host:
+db_port:
+db_name:
+db_user:
+db_pass:
+app_port:

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,4 +1,25 @@
-- name: Fix apt sources to use HTTPS
+- name: Ensure Python is installed (Bootstrap)
+  ansible.builtin.raw: test -e /usr/bin/python3 || (apt update && apt install -y python3)
+  changed_when: false
+
+- name: Configure temporary HTTP sources for bootstrap
+  ansible.builtin.copy:
+    dest: /etc/apt/sources.list
+    content: |
+      deb http://archive.ubuntu.com/ubuntu jammy main universe
+    mode: '0644'
+
+- name: Install CA certificates and base dependencies
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - python3-apt
+      - curl
+      - gnupg
+    state: present
+    update_cache: true
+
+- name: Configure permanent HTTPS production sources
   ansible.builtin.copy:
     dest: /etc/apt/sources.list
     content: |
@@ -8,11 +29,7 @@
       deb https://security.ubuntu.com/ubuntu jammy-security main restricted universe multiverse
     mode: '0644'
 
-- name: Clean apt cache
-  ansible.builtin.apt:
-    clean: true
-
-- name: Update apt cache with retries
+- name: Final update of apt cache with retries
   ansible.builtin.apt:
     update_cache: true
   register: common_apt_update
@@ -20,14 +37,9 @@
   delay: 10
   until: common_apt_update is succeeded
 
-- name: Ensure Python is installed
-  ansible.builtin.raw: test -e /usr/bin/python3 || (apt update && apt install -y python3)
-  changed_when: false
-
-- name: Install base packages
-  ansible.builtin.apt:
-    name:
-      - python3
-      - python3-apt
-      - curl
+- name: Create application user
+  ansible.builtin.user:
+    name: appuser
+    shell: /bin/bash
+    create_home: true
     state: present

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,33 +1,73 @@
 resource "docker_network" "app_network" {
-  name = "app_network"
+  name     = var.network_name
+  driver   = var.network_driver
+  internal = var.network_internal
+}
+
+locals {
+  image_web = length(trimspace(var.image_web)) > 0 ? var.image_web : var.image
+  image_app = length(trimspace(var.image_app)) > 0 ? var.image_app : var.image
+  image_db  = length(trimspace(var.image_db)) > 0 ? var.image_db : var.image
 }
 
 resource "docker_container" "web" {
   name    = "web_node"
-  image   = "ubuntu:22.04"
+  image   = local.image_web
   command = ["sleep", "infinity"]
-  restart = "always"
+  restart = var.restart_policy
+
+  ports {
+    internal = var.web_container_port
+    external = var.web_host_port
+  }
+
   networks_advanced {
     name = docker_network.app_network.name
+  }
+
+  healthcheck {
+    test         = ["CMD-SHELL", "curl -f http://localhost:${var.web_container_port}/health || exit 1"]
+    interval     = "30s"
+    timeout      = "5s"
+    retries      = 3
+    start_period = var.healthcheck_start_period
   }
 }
 
 resource "docker_container" "app" {
   name    = "app_node"
-  image   = "ubuntu:22.04"
+  image   = local.image_app
   command = ["sleep", "infinity"]
-  restart = "always"
+  restart = var.restart_policy
+
   networks_advanced {
     name = docker_network.app_network.name
+  }
+
+  healthcheck {
+    test         = ["CMD-SHELL", "curl -f http://localhost:${var.app_container_port}/health || exit 1"]
+    interval     = "30s"
+    timeout      = "5s"
+    retries      = 3
+    start_period = var.healthcheck_start_period
   }
 }
 
 resource "docker_container" "db" {
   name    = "db_node"
-  image   = "ubuntu:22.04"
+  image   = local.image_db
   command = ["sleep", "infinity"]
-  restart = "always"
+  restart = var.restart_policy
+
   networks_advanced {
     name = docker_network.app_network.name
+  }
+
+  healthcheck {
+    test         = ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+    interval     = "30s"
+    timeout      = "5s"
+    retries      = 3
+    start_period = var.healthcheck_start_period
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,7 +1,12 @@
 output "container_ips" {
   value = {
-    web = docker_container.web.network_data[0].ip_address
-    app = docker_container.app.network_data[0].ip_address
-    db  = docker_container.db.network_data[0].ip_address
+    web = try(docker_container.web.network_data[0].ip_address, "")
+    app = try(docker_container.app.network_data[0].ip_address, "")
+    db  = try(docker_container.db.network_data[0].ip_address, "")
   }
+}
+
+output "web_host_port" {
+  value       = var.web_host_port
+  description = "Host port mapped to the web (nginx) container"
 }

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Example overrides for local development. Copy to terraform/terraform.tfvars to apply locally.
+image = "ubuntu:22.04"
+# To switch to service-specific images (optional):
+# image_web = "python:3.11-slim"
+# image_app = "python:3.11-slim"
+# image_db  = "postgres:15"
+
+web_host_port = 8080
+healthcheck_start_period = "180s"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,77 @@
+variable "image" {
+  description = "Fallback base image used for containers"
+  type        = string
+  default     = "ubuntu:22.04"
+}
+
+variable "image_web" {
+  description = "Web node image"
+  type        = string
+  default     = ""
+}
+
+variable "image_app" {
+  description = "App node image"
+  type        = string
+  default     = ""
+}
+
+variable "image_db" {
+  description = "DB node image"
+  type        = string
+  default     = ""
+}
+
+variable "network_name" {
+  description = "Docker network name"
+  type        = string
+  default     = "app_network"
+}
+
+variable "network_driver" {
+  description = "Docker network driver"
+  type        = string
+  default     = "bridge"
+}
+
+variable "network_internal" {
+  description = "Whether the docker network is internal. Set false if apt/pip must reach internet during provisioning."
+  type        = bool
+  default     = false
+}
+
+variable "restart_policy" {
+  description = "Restart policy for containers."
+  type        = string
+  default     = "unless-stopped"
+}
+
+variable "web_host_port" {
+  description = "Host port mapped to the web container (nginx)"
+  type        = number
+  default     = 8080
+}
+
+variable "web_container_port" {
+  description = "Container port nginx will listen on"
+  type        = number
+  default     = 80
+}
+
+variable "app_container_port" {
+  description = "Application container port (Flask)"
+  type        = number
+  default     = 5000
+}
+
+variable "db_container_port" {
+  description = "Database container internal port"
+  type        = number
+  default     = 5432
+}
+
+variable "healthcheck_start_period" {
+  description = "Healthcheck start_period to allow Ansible provisioning to complete before checks begin"
+  type        = string
+  default     = "180s"
+}


### PR DESCRIPTION
## Summary
I created the Ansible app role to configure the 
application container with Flask and deploy 
the app to /var/www/app on port 5000.

## Why this change?
The app node needed its own role to install 
dependencies and run the application service 
as part of the multi-tier environment.

## How I tested it
- [x] CI pipeline passed (terraform + ansible)
- [x] ansible-lint violations resolved
- [x] Verified via GitHub Actions

## Related issue
Closes #6

## Screenshots
<img width="1366" height="729" alt="Issue #6 failed1" src="https://github.com/user-attachments/assets/9d3b4080-0822-4db7-a9a8-0fe37387bba8" />

<img width="1365" height="754" alt="Issue #6 Success" src="https://github.com/user-attachments/assets/06981611-6858-4fc0-9391-9eb0fc039f44" />

CI passed ✅
- terraform: passed
- ansible: passed

## Checklist
- [x] My change was focused (app role)
- [x] I tested the change
